### PR TITLE
Fix wrong mapping of Menu, M1, and M2 buttons

### DIFF
--- a/ally.css
+++ b/ally.css
@@ -136,7 +136,7 @@ img[src="/steaminputglyphs/ps_lb.svg"] {
     transform: scale(0.88);
 }*/
 img[src="/steaminputglyphs/ps_lfn.svg"] {
-    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/M1.png");
+    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/M2.png");
     transform: scale(0.88);
 }
 /*
@@ -145,7 +145,7 @@ img[src="/steaminputglyphs/ps_rb.svg"] {
     transform: scale(0.88);
 }*/
 img[src="/steaminputglyphs/ps_rfn.svg"] {
-    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/M2.png");
+    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/M1.png");
     transform: scale(0.88);
 }
 
@@ -155,7 +155,7 @@ img[src="/steaminputglyphs/ps5_button_create.svg"] {
     transform: scale(0.88);
 }
 img[src="/steaminputglyphs/ps5_button_options.svg"] {
-    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/Armoury_Crate.png");
+    content: url("/themes_custom/SBP-ROG-Ally/ally-buttons/Menu.png");
     transform: scale(0.88);
 }
 img[src="/steaminputglyphs/sd_l2.svg"] {


### PR DESCRIPTION
Menu button was incorrect, it showed one of the special Asus buttons instead of the hamburguer button, which is what Menu actually maps to.

M1 and M2 were also backwards (understandably, as the way Asus does this is kinda weird). You can verify the issue by vieweing the Steam button mappings, then checking your physical Ally back buttons. You'll notice Steam shows M2 as M1, and vice-versa.

Both issues are fixed here.